### PR TITLE
refactor(emojify): remove emoji unicode mapping

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "babel-plugin-styled-components": "^1.10.7",
     "color": "^3.1.2",
     "dotenv": "^8.2.0",
-    "emoji-unicode-map": "^1.1.10",
     "gatsby": "^2.23.3",
     "gatsby-image": "^2.4.7",
     "gatsby-plugin-manifest": "^2.4.11",

--- a/src/layout/emojify-toggle/__snapshots__/emojify-toggle.test.tsx.snap
+++ b/src/layout/emojify-toggle/__snapshots__/emojify-toggle.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`EmojifyToggle renders correctly 1`] = `
   type="button"
 >
   <span
-    aria-label="Monkey Face"
+    aria-hidden="true"
     class="c1"
     role="img"
   >

--- a/src/layout/emojify-toggle/emojify-toggle.tsx
+++ b/src/layout/emojify-toggle/emojify-toggle.tsx
@@ -8,7 +8,6 @@ export const EmojifyToggle: React.FC = () => {
   const { emojified, setEmojified } = React.useContext(EmojifyContext);
   const buttonText = emojified ? 'Hide Emoji' : 'Show Emoji';
   const emoji = emojified ? '🙈' : '🐵';
-  const emojiText = emojified ? 'See-No-Evil Monkey' : 'Monkey Face';
 
   return (
     <Styled.Button
@@ -16,7 +15,7 @@ export const EmojifyToggle: React.FC = () => {
       aria-label={buttonText}
       onClick={() => setEmojified(!emojified)}
     >
-      <Styled.Emoji role="img" aria-label={emojiText}>
+      <Styled.Emoji role="img" aria-hidden="true">
         {emoji}
       </Styled.Emoji>
     </Styled.Button>

--- a/src/layout/emojify/__snapshots__/emojify.test.tsx.snap
+++ b/src/layout/emojify/__snapshots__/emojify.test.tsx.snap
@@ -35,7 +35,7 @@ exports[`Emojify renders correctly 1`] = `
     type="button"
   >
     <span
-      aria-label="See-No-Evil Monkey"
+      aria-hidden="true"
       class="c2"
       role="img"
     >

--- a/src/layout/emojify/emojify.stories.tsx
+++ b/src/layout/emojify/emojify.stories.tsx
@@ -18,12 +18,3 @@ export const Default = () => (
     <Emojify emoji="🤩" />
   </>
 );
-
-export const UnknownEmoji = () => (
-  <>
-    <Paragraph>
-      Click me ➜<EmojifyToggle />
-    </Paragraph>
-    <Emojify emoji="👩🏻‍🦽" />
-  </>
-);

--- a/src/layout/emojify/emojify.test.tsx
+++ b/src/layout/emojify/emojify.test.tsx
@@ -5,7 +5,7 @@ import user from '@testing-library/user-event';
 import { render } from '../../services/test-utils';
 import { EmojifyProvider } from '../../contexts';
 
-import { Default, UnknownEmoji } from './emojify.stories';
+import { Default } from './emojify.stories';
 
 const App: React.FC = ({ children }) => (
   <EmojifyProvider>{children}</EmojifyProvider>
@@ -28,17 +28,6 @@ describe('Emojify', () => {
     const { container } = render(
       <App>
         <Default />
-      </App>
-    );
-    const results = await axe(container);
-
-    expect(results).toHaveNoViolations();
-  });
-
-  test('is accessible when no text is returned', async () => {
-    const { container } = render(
-      <App>
-        <UnknownEmoji />
       </App>
     );
     const results = await axe(container);

--- a/src/layout/emojify/emojify.tsx
+++ b/src/layout/emojify/emojify.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import unicode from 'emoji-unicode-map';
 
 import { EmojifyContext } from '../../contexts';
 
@@ -11,12 +10,9 @@ export type EmojifyProps = {
 
 export const Emojify: React.FC<EmojifyProps> = ({ emoji, ...props }) => {
   const { emojified } = React.useContext(EmojifyContext);
-  const emojiText = unicode.get(emoji);
-  const emojiLabel =
-    emojiText === undefined ? 'emoji' : String(emojiText.replace('_', ' '));
 
   return emojified ? (
-    <Styled.Emoji role="img" aria-label={emojiLabel} {...props}>
+    <Styled.Emoji role="img" aria-hidden="true" {...props}>
       {' '}
       {emoji}{' '}
     </Styled.Emoji>

--- a/src/typings/emoji-unicode-map.d.ts
+++ b/src/typings/emoji-unicode-map.d.ts
@@ -1,3 +1,0 @@
-declare module 'emoji-unicode-map' {
-  function get(char: string): string;
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9153,15 +9153,6 @@ elliptic@^6.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
-emoji-name-map@^1.1.0:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/emoji-name-map/-/emoji-name-map-1.2.8.tgz#4bd5c6bfe3ae4bffc7d8ff60c0da57a91df3a0b4"
-  integrity sha512-UxX9lJXCmwqLaRCkprtXZAEMDNk0z7IbNaUJ51gZouq7/9j2IiqsrmUGo/fLd2YgwZFElWlItsjQo86fz4l2zA==
-  dependencies:
-    emojilib "^2.0.2"
-    iterate-object "^1.3.1"
-    map-o "^2.0.1"
-
 "emoji-regex@>=6.0.0 <=6.1.1":
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.1.1.tgz#c6cd0ec1b0642e2a3c67a1137efc5e796da4f88e"
@@ -9176,19 +9167,6 @@ emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
-
-emoji-unicode-map@^1.1.10:
-  version "1.1.10"
-  resolved "https://registry.yarnpkg.com/emoji-unicode-map/-/emoji-unicode-map-1.1.10.tgz#060d165496e70a78f428447c2ea222ffc70aaa2f"
-  integrity sha512-03aFWD+dsWbl0JpzWGYQ5z9xsJH47uykUbYjmTKdNbZjtAUiLGTQmFBJUMI0/jW0GjiK/zSkivjkRuPqcdfNIw==
-  dependencies:
-    emoji-name-map "^1.1.0"
-    iterate-object "^1.3.1"
-
-emojilib@^2.0.2:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/emojilib/-/emojilib-2.4.0.tgz#ac518a8bb0d5f76dda57289ccb2fdf9d39ae721e"
-  integrity sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==
 
 emojis-list@^2.0.0:
   version "2.1.0"
@@ -13968,11 +13946,6 @@ iterate-iterator@^1.0.1:
   resolved "https://registry.yarnpkg.com/iterate-iterator/-/iterate-iterator-1.0.1.tgz#1693a768c1ddd79c969051459453f082fe82e9f6"
   integrity sha512-3Q6tudGN05kbkDQDI4CqjaBf4qf85w6W6GnuZDtUVYwKgtC1q8yxYX7CZed7N+tLzQqS6roujWvszf13T+n9aw==
 
-iterate-object@^1.3.0, iterate-object@^1.3.1:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/iterate-object/-/iterate-object-1.3.3.tgz#c58e60f7f0caefa2d382027a484b215988a7a296"
-  integrity sha512-DximWbkke36cnrSfNJv6bgcB2QOMV9PRD2FiowwzCoMsh8RupFLdbNIzWe+cVDWT+NIMNJgGlB1dGxP6kpzGtA==
-
 iterate-value@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/iterate-value/-/iterate-value-1.0.2.tgz#935115bd37d006a52046535ebc8d07e9c9337f57"
@@ -15366,13 +15339,6 @@ map-cache@^0.2.0, map-cache@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
   integrity sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=
-
-map-o@^2.0.1:
-  version "2.0.9"
-  resolved "https://registry.yarnpkg.com/map-o/-/map-o-2.0.9.tgz#7e7b4bc7b192fd3ca2cda230eaf9d8e3dd5f86ce"
-  integrity sha512-oYdT5amkNO06ZS/+x6qQ6SAz+/k9lByczvBZn8RKnwzWOb9FDlb1NCwBTtjOmloeh4sOuxkxeGf0s2ruSUieEg==
-  dependencies:
-    iterate-object "^1.3.0"
 
 map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
The usefulness of the package was out of proportion with its package size. 200 KB for just naming some Emoji is too much.